### PR TITLE
Checks getUserId() is not null before comparison

### DIFF
--- a/backend/src/main/java/de/interaapps/pastefy/controller/PasteController.java
+++ b/backend/src/main/java/de/interaapps/pastefy/controller/PasteController.java
@@ -87,7 +87,7 @@ public class PasteController extends HttpController {
         ActionResponse response = new ActionResponse();
         Paste paste = Repo.get(Paste.class).where("key", id).first();
         if (paste != null) {
-            if (paste.getUserId().equals(user.getId()) || user.type == User.Type.ADMIN) {
+            if ((paste.getUserId() != null && paste.getUserId().equals(user.getId())) || user.type == User.Type.ADMIN) {
                 if (request.title != null)
                     paste.setTitle(request.title);
                 if (request.content != null)
@@ -125,7 +125,7 @@ public class PasteController extends HttpController {
         Paste paste = Repo.get(Paste.class).where("key", id).first();
 
         if (paste != null) {
-            if (paste.getUserId().equals(user.getId()) || user.type == User.Type.ADMIN) {
+            if ((paste.getUserId() != null && paste.getUserId().equals(user.getId())) || user.type == User.Type.ADMIN) {
                 paste.delete();
                 response.success = true;
             } else


### PR DESCRIPTION
Pastes created by anonymous users can't be deleted through the admin panel because the user ID is null and throws a NullPointerException. Editing existing pastes can't currently be done by admins but this condition was also fixed to avoid the same issue if enabled in future.