### PR TITLE
docs: update docker-compose.yml link to remove pastefy.ga reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker-compose up
 ```
 
 ### Custom Docker-Compose (Using Docker-Hub)
-https://pastefy.ga/Hj9N3bs2
+https://pastefy.app/Hj9N3bs2
 ```bash
 wget https://pastefy.app/Hj9N3bs2/raw -O docker-compose.yml
 nano docker-compose.yml


### PR DESCRIPTION
fixes #99

pastefy.ga seems to serve malicious content. The README still contains a link to the docker-compose.yml snippet for Docker Hub users containing that domain. It seems like the URL path stays the same under the pastefy.app domain, so I just replaced the domain.