### PR TITLE
Fix GitHub OAuth2 failed if user name is null

### DIFF
--- a/backend/src/main/java/de/interaapps/pastefy/auth/strategies/oauth2/providers/GitHubOAuth2Provider.java
+++ b/backend/src/main/java/de/interaapps/pastefy/auth/strategies/oauth2/providers/GitHubOAuth2Provider.java
@@ -73,6 +73,8 @@ public class GitHubOAuth2Provider implements OAuth2Provider {
                 profile.id = userData.get("id").number().toString();
             if (userData.has("name"))
                 profile.name = userData.get("name").string();
+            else if (userData.has("login"))
+                profile.name = userData.get("login").string();
             if (userData.has("avatar_url"))
                 profile.avatar = userData.get("avatar_url").string();
 


### PR DESCRIPTION
GitHub OAuth2 fails with the following error if user's name is unset:
```
pastefy-1  | java.lang.NullPointerException: Cannot invoke "String.replaceAll(String, String)" because the return value of "de.interaapps.pastefy.auth.strategies.oauth2.OAuth2Profile.getName()" is null
pastefy-1  | 	at de.interaapps.pastefy.auth.OAuth2Callback.handle(OAuth2Callback.java:21)
pastefy-1  | 	at de.interaapps.pastefy.auth.strategies.oauth2.OAuth2Strategy.lambda$createRoutes$1(OAuth2Strategy.java:36)
pastefy-1  | 	at org.javawebstack.http.router.HTTPRouter.execute(HTTPRouter.java:399)
pastefy-1  | 	at org.javawebstack.http.router.HTTPRouter.lambda$start$2(HTTPRouter.java:337)
pastefy-1  | 	at org.javawebstack.http.router.undertow.UndertowHTTPSocketServer.lambda$start$1(UndertowHTTPSocketServer.java:50)
pastefy-1  | 	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:395)
pastefy-1  | 	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:859)
pastefy-1  | 	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
pastefy-1  | 	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
pastefy-1  | 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
pastefy-1  | 	at org.xnio.XnioWorker$WorkerThreadFactory$1$1.run(XnioWorker.java:1282)

```